### PR TITLE
Added option to pass client certificate for authentication to website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Nagios HTTP/HTTPS check via wget (with/without Proxy).
     	-c CRITICAL	critical threshold in milliseconds (default: 2000)
     	-n TRIES	number of times to try (default: 1)
     	-t TIMEOUT	amount of time to wait in seconds (default: 10)
+		-C CERTIFICATE client certificate stored in file location (PEM AND DER file types allowed)
 
 ##Examples:##
 
@@ -42,6 +43,11 @@ Check on a non default port with a fixed url expecting a ssl connection via prox
 
     $ ./check_website -p 8080 -u /index.html -s -P 192.168.27.111:3128 -c 4000 -w 1500 www.myweb.com
     HTTPS OK: 274ms - https://www.myweb.com:8080/index.html|time=274ms;1500;4000;0;
+	
+Check through proxy passing client certificate for authentication.
+
+	./check_website -P squid.example.com:3128 -u /ping -s -w 2000 -c 5000 -C /root/certs/client_cert.pem www.example.com
+	HTTPS OK: 412ms - https://www.example.com/ping|time=412ms;2000;5000;0;
 
 ##Return Values:##
 

--- a/check_website
+++ b/check_website
@@ -17,6 +17,7 @@ times=1
 timeout=10
 warning=500
 critical=2000
+certificate=""
 
 #functions
 #set system proxy from environment
@@ -47,7 +48,8 @@ function usage() {
 	-w WARNING	warning threshold in milliseconds (default: 500)
 	-c CRITICAL	critical threshold in milliseconds (default: 2000)
 	-n TRIES	number of times to try (default: 1)
-	-t TIMEOUT	amount of time to wait in seconds (default: 10)'''
+	-t TIMEOUT	amount of time to wait in seconds (default: 10)
+	-C CERTIFICATE client certificate stored in file location (PEM AND DER file types allowed)'''
 	version
 }
 
@@ -75,7 +77,7 @@ function getStatus() {
 
 #main
 #get options
-while getopts "w:c:p:sfu:P:n:t:" opt; do
+while getopts "w:c:p:sfu:P:n:t:C:" opt; do
     case $opt in
 	w)
             warning=$OPTARG
@@ -104,6 +106,9 @@ while getopts "w:c:p:sfu:P:n:t:" opt; do
         t)
             timeout=$OPTARG
             ;;
+	C)
+	    client_certificate=$OPTARG
+	    ;;
         *)
 	    usage
             exit 3
@@ -152,19 +157,35 @@ if [ -z "$wget" ]; then
 fi	
 
 #check fake user agent
-if [ -z "$fake" ]; then
+if [ -z "$fake" ] && [ -z "$client_certificate" ]; then
 	#execute and capture execution time and return status of wget
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget --no-check-certificate -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url
+	status=$?
+	end=$(echo $(($(date +%s%N)/1000000)))
+elif [ -z "$fake" ] && [ -n "$client_certificate" ]; then
+	#execute and capture execution time and return status of wget with client certificate
+	start=$(echo $(($(date +%s%N)/1000000)))
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd --certificate=$client_certificate $url
+	status=$?
+	end=$(echo $(($(date +%s%N)/1000000)))
+elif [ -n "$fake" ] && [ -n "$client_certificate" ]; then
+	#execute with fake user agent and capture execution time and return status of wget with client certificate
+	start=$(echo $(($(date +%s%N)/1000000)))
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd --certificate=$client_certificate $url \
+	--header="User-Agent: Mozilla/5.0 (Windows NT 5.1; rv:25.0) Gecko/20100101 Firefox/25.0" \
+	--header="Accept: image/png,image/*;q=0.8,*/*;q=0.5" \
+	--header="Accept-Language: en-us,en;q=0.5" \
+	--header="Accept-Encoding: gzip, deflate" 
 	status=$?
 	end=$(echo $(($(date +%s%N)/1000000)))
 else
 	#execute with fake user agent and capture execution time and return status of wget
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget --no-check-certificate -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url \
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url \
 	--header="User-Agent: Mozilla/5.0 (Windows NT 5.1; rv:25.0) Gecko/20100101 Firefox/25.0" \
 	--header="Accept: image/png,image/*;q=0.8,*/*;q=0.5" \
-	--header="Accept-Language: de-DE,de;q=0.5" \
+	--header="Accept-Language: en-us,en;q=0.5" \
 	--header="Accept-Encoding: gzip, deflate" 
 	status=$?
 	end=$(echo $(($(date +%s%N)/1000000)))


### PR DESCRIPTION
Added option to pass client certificate for authentication when running check.

Also removed "--no-check-certificate" option that is hard coded in is not security best practice, I want to know if website is having cert issue and not trusted. If using self-signed, etc. need to be proactive and add certs to server trusted cert store of Nagios server.
