### PR TITLE
add bind address option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Nagios HTTP/HTTPS check via wget (with/without Proxy).
     	-n TRIES	number of times to try (default: 1)
     	-t TIMEOUT	amount of time to wait in seconds (default: 10)
 		-C CERTIFICATE client certificate stored in file location (PEM AND DER file types allowed)
+    	-b IP		bind ip address used by wget (default: primary system address)
 
 ##Examples:##
 

--- a/check_website
+++ b/check_website
@@ -18,6 +18,7 @@ timeout=10
 warning=500
 critical=2000
 certificate=""
+bindaddress=""
 
 #functions
 #set system proxy from environment
@@ -49,7 +50,8 @@ function usage() {
 	-c CRITICAL	critical threshold in milliseconds (default: 2000)
 	-n TRIES	number of times to try (default: 1)
 	-t TIMEOUT	amount of time to wait in seconds (default: 10)
-	-C CERTIFICATE client certificate stored in file location (PEM AND DER file types allowed)'''
+	-C CERTIFICATE client certificate stored in file location (PEM AND DER file types allowed)
+	-b IP		bind ip address used by wget (default: primary system address)'''
 	version
 }
 
@@ -77,7 +79,7 @@ function getStatus() {
 
 #main
 #get options
-while getopts "w:c:p:sfu:P:n:t:C:" opt; do
+while getopts "w:c:p:sfu:P:n:t:C:b:" opt; do
     case $opt in
 	w)
             warning=$OPTARG
@@ -108,6 +110,9 @@ while getopts "w:c:p:sfu:P:n:t:C:" opt; do
             ;;
 	C)
 	    client_certificate=$OPTARG
+	    ;;
+	b)
+	    bindaddress=$OPTARG
 	    ;;
         *)
 	    usage
@@ -156,23 +161,29 @@ if [ -z "$wget" ]; then
 	exit 3
 fi
 
+#check for bindaddress
+bindaddress_cmd=""
+if [ ! -z "bindaddress" ]; then
+  bindaddress_cmd="--bind-address=${bindaddress}"
+fi
+
 #check fake user agent
 if [ -z "$fake" ] && [ -z "$client_certificate" ]; then
 	#execute and capture execution time and return status of wget
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $bindaddress_cmd $url
 	status=$?
 	end=$(echo $(($(date +%s%N)/1000000)))
 elif [ -z "$fake" ] && [ -n "$client_certificate" ]; then
 	#execute and capture execution time and return status of wget with client certificate
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd --certificate=$client_certificate $url
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $bindaddress_cmd --certificate=$client_certificate $url
 	status=$?
 	end=$(echo $(($(date +%s%N)/1000000)))
 elif [ -n "$fake" ] && [ -n "$client_certificate" ]; then
 	#execute with fake user agent and capture execution time and return status of wget with client certificate
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd --certificate=$client_certificate $url \
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $bindaddress_cmd --certificate=$client_certificate $url \
 	--header="User-Agent: Mozilla/5.0 (Windows NT 5.1; rv:25.0) Gecko/20100101 Firefox/25.0" \
 	--header="Accept: image/png,image/*;q=0.8,*/*;q=0.5" \
 	--header="Accept-Language: en-us,en;q=0.5" \
@@ -182,7 +193,7 @@ elif [ -n "$fake" ] && [ -n "$client_certificate" ]; then
 else
 	#execute with fake user agent and capture execution time and return status of wget
 	start=$(echo $(($(date +%s%N)/1000000)))
-	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $url \
+	$wget -t $times --timeout $timeout -O /dev/null -q -e $proxy_cmd $bindaddress_cmd $url \
 	--header="User-Agent: Mozilla/5.0 (Windows NT 5.1; rv:25.0) Gecko/20100101 Firefox/25.0" \
 	--header="Accept: image/png,image/*;q=0.8,*/*;q=0.5" \
 	--header="Accept-Language: en-us,en;q=0.5" \


### PR DESCRIPTION
This patch comes very handy on systems with multiple ip addresses, where a specific (non management) ip address should be used for the website check.
